### PR TITLE
Add WIP order board menu fix

### DIFF
--- a/RF5Fix.cs
+++ b/RF5Fix.cs
@@ -286,6 +286,7 @@ namespace RF5Fix
             [HarmonyPatch(typeof(CampMenuMain), nameof(CampMenuMain.StartCamp))] // Camp menu
             [HarmonyPatch(typeof(MovieRoom), nameof(MovieRoom.Start))] // Movie gallery
             [HarmonyPatch(typeof(MapControl), nameof(MapControl.Start))] // Map
+            [HarmonyPatch(typeof(UIOrderBoardMenu), nameof(UIOrderBoardMenu.Start))] // Order Board
             [HarmonyPostfix]
             public static void EnableLetterboxing()
             {
@@ -300,6 +301,7 @@ namespace RF5Fix
             [HarmonyPatch(typeof(CampMenuMain), nameof(CampMenuMain.CloseCamp))] // Camp menu
             [HarmonyPatch(typeof(MovieRoom), nameof(MovieRoom.Close))] // Movie gallery
             [HarmonyPatch(typeof(MapControl), nameof(MapControl.OnDestroy))] // Map
+            [HarmonyPatch(typeof(UIOrderBoardMenu), nameof(UIOrderBoardMenu.OnDisable))] // Order Board
             [HarmonyPostfix]
             public static void DisableLetterboxing()
             {


### PR DESCRIPTION
This should disable pillarboxing when entering the order board menu, alongside disabling it when exiting. OnDestroy and Close functions seemingly aren't used here (and Rider on my Linux workstation doesn't seem to be letting me compile a .DLL file that the game detects), so it's entirely possible that this solution may need further testing.